### PR TITLE
separate out receive thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "parking_lot"
@@ -913,6 +913,7 @@ dependencies = [
  "futures",
  "log",
  "nix",
+ "once_cell",
  "rand",
  "regex",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ structopt = "0.3"
 bytes = "1.1"
 rand = "0.8.5"
 futures = "0.3.21"
+once_cell = "1.10.0"
 
 [dev-dependencies]
 console-subscriber = "0.1.3"

--- a/examples/tcp_local_large_body.rs
+++ b/examples/tcp_local_large_body.rs
@@ -10,6 +10,7 @@ use rena::frames::arp::ArpOperation;
 use rena::frames::ethernet::EtherType;
 use rena::frames::ethernet::EthernetFrame;
 use rena::packet::ArpPacket;
+use rena::tcp::frame_receiver::FrameReceiver;
 use rena::tcp::local_handler::LocalHandler;
 use std::io;
 use std::sync::Arc;
@@ -78,6 +79,8 @@ async fn main() {
                         .unwrap();
 
                     let smacaddr = sock.mac_addr;
+                    let receiver = FrameReceiver::new();
+
                     let mut handler = LocalHandler::connect(
                         smacaddr,
                         arp.source_macaddr(),
@@ -86,6 +89,7 @@ async fn main() {
                         sport,
                         dport,
                         sock,
+                        receiver,
                     )
                     .await
                     .unwrap();

--- a/src/frames/tcp.rs
+++ b/src/frames/tcp.rs
@@ -212,6 +212,10 @@ impl TcpFrame {
         frame
     }
 
+    pub fn dport(&self) -> u16 {
+        self.dport
+    }
+
     pub fn window_size(&self) -> u16 {
         self.window_size
     }

--- a/src/tcp/frame_receiver.rs
+++ b/src/tcp/frame_receiver.rs
@@ -33,7 +33,7 @@ impl FrameReceiver {
         }
     }
 
-    pub fn subscribe(&self, dport: u16, subscriber: &mut dyn Subscriber) {
+    pub fn subscribe(&self, sport: u16, subscriber: &mut dyn Subscriber) {
         if self.subscriptions_locked {
             return;
         }
@@ -43,7 +43,7 @@ impl FrameReceiver {
 
         // This unsafe is safe because subscription is not allowed after receiver thread is started.
         unsafe {
-            WORKER_SUBSCRIPTIONS.insert(dport, tx);
+            WORKER_SUBSCRIPTIONS.insert(sport, tx);
         }
     }
 

--- a/src/tcp/frame_receiver.rs
+++ b/src/tcp/frame_receiver.rs
@@ -1,0 +1,64 @@
+use std::{collections::HashMap, sync::Arc};
+
+use crate::frames::tcp::TcpFrame;
+use crate::{
+    datalink::{
+        reader::{read, ReadResult},
+        traits::DatalinkReaderWriter,
+    },
+    frames::{
+        ethernet::{EtherType, EthernetFrame},
+        ipv4::IpProtocol,
+    },
+};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+pub struct FrameReceiver {
+    handle: Option<JoinHandle<()>>,
+    subscriptions: HashMap<u16, mpsc::Sender<TcpFrame>>,
+}
+
+impl FrameReceiver {
+    pub fn new(sock: Arc<dyn DatalinkReaderWriter>) -> Self {
+        let receiver = Self {
+            handle: None,
+            subscriptions: HashMap::new(),
+        };
+
+        let handle = tokio::spawn(async {
+            loop {
+                let res = read(sock, None).await;
+                match res {
+                    ReadResult::Success(buf) => {
+                        let ether = EthernetFrame::from_raw(&mut buf);
+                        if ether.frame_type() != EtherType::Ipv4 {
+                            continue;
+                        }
+
+                        let ip = ether.ipv4_payload();
+                        if ip.is_err() {
+                            continue;
+                        }
+
+                        let ip = ip.unwrap();
+                        if ip.protocol() != IpProtocol::Tcp {
+                            continue;
+                        }
+
+                        let tcp = ip.tcp_payload();
+                        if tcp.is_err() {
+                            continue;
+                        }
+
+                        let dport = tcp.unwrap().dport();
+                    }
+                    ReadResult::Timeout => {}
+                }
+            }
+        });
+
+        receiver.handle = Some(handle);
+        receiver
+    }
+}

--- a/src/tcp/local_handler.rs
+++ b/src/tcp/local_handler.rs
@@ -238,27 +238,3 @@ impl LocalHandler {
         chunked_raw_frames
     }
 }
-
-fn parse_tcp_packet<'a>(mut buf: Buffer) -> Result<TcpFrame> {
-    let ether = EthernetFrame::from_raw(&mut buf);
-    if ether.frame_type() != EtherType::Ipv4 {
-        return Err(anyhow!("not ipv4"));
-    }
-
-    let ip = ether.ipv4_payload();
-    if ip.is_err() {
-        return Err(anyhow!("failed to parse ipv4"));
-    }
-
-    let ip = ip.unwrap();
-    if ip.protocol() != IpProtocol::Tcp {
-        return Err(anyhow!("not tcp"));
-    }
-
-    let tcp = ip.tcp_payload();
-    if tcp.is_err() {
-        return Err(anyhow!("failed to parse tcp payload"));
-    }
-
-    Ok(tcp.unwrap().to_owned())
-}

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -1,3 +1,4 @@
 pub mod active_session;
+pub mod frame_receiver;
 pub mod local_handler;
 pub mod state;

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -2,3 +2,4 @@ pub mod active_session;
 pub mod frame_receiver;
 pub mod local_handler;
 pub mod state;
+mod subscriber;

--- a/src/tcp/subscriber.rs
+++ b/src/tcp/subscriber.rs
@@ -1,0 +1,7 @@
+use tokio::sync::mpsc;
+
+use crate::frames::tcp::TcpFrame;
+
+pub trait Subscriber {
+    fn subscribe(&mut self, rx: mpsc::Receiver<TcpFrame>);
+}


### PR DESCRIPTION
In the current implementation, we may face massive copies via massive fds. This PR constructs `1 (recv thread) :N (main threads)` PubSub model and creates only 1 fd. If recv thread received message, it will send memory to a valid thread via dport. 